### PR TITLE
Add cmp-array function

### DIFF
--- a/doc/test-more.swim
+++ b/doc/test-more.swim
@@ -46,6 +46,10 @@ Write a test file like this. Maybe call it `test/test.t`:
 
   note "A message for stdout"
 
+  output=( $(ls) )
+  expected=(README lib bin)
+  cmp-array "list files" ${output[@]}
+
 Run the test with `prove` like this:
 
   prove test/test.t
@@ -75,6 +79,7 @@ This is the basic usage:
 * `done_testing $count`
 * `plan skip_all "$reason"`
 * `BAIL_OUT "$reason"`
+* `cmp-array "message" ${array[@]}`
 
 More detailed info coming soon.
 

--- a/lib/test/more.bash
+++ b/lib/test/more.bash
@@ -93,3 +93,45 @@ unlike() {
 Test::More:unlike-fail() {
     Test::Tap:diag "Got: '$got'"
 }
+
+cmp-array() {
+    if [[ $# -lt 2 ]]; then
+        echo 'usage: cmp-array "message" ${array[@]}'
+        exit 1
+    fi
+    local label="$1"
+    shift
+    local array=($@)
+    local result=true
+    local message=
+
+    if [[ ${#array[@]} -lt ${#expected[@]} ]]; then
+        Test::Tap:fail "$label"
+        Test::Tap:diag "Array has less elements (${#array[@]}) than expected (${#expected[@]})"
+        Test::Tap:note ${array[@]}
+        return
+    fi
+
+    for i in ${!expected[@]}; do
+        if [[ "${array[$i]}" == "${expected[$i]}" ]]; then
+            true
+        else
+            message="array[$i]: >>${array[$i]}<< does not match >>${expected[$i]}<<"
+            result=false
+        fi
+    done
+
+    if [[ ${#array[@]} -gt ${#expected[@]} ]]; then
+        Test::Tap:fail "$label"
+        Test::Tap:diag "Array has more elements (${#array[@]}) than expected (${#expected[@]})"
+        Test::Tap:note ${array[@]}
+        return
+    fi
+
+    if $result; then
+        Test::Tap:pass "$label"
+    else
+        Test::Tap:fail "$label"
+    fi
+    [[ -n "$message" ]] && Test::Tap:diag $message
+}

--- a/test/fail.t
+++ b/test/fail.t
@@ -12,9 +12,23 @@ like "$output" 'not ok 2' \
   'fail with no label'
 like "$output" 'not ok 3 - is foo bar' \
   'fail output is correct'
+like "$output" 'not ok 4 - command output more' \
+  'fail output is correct'
+like "$output" 'not ok 5 - command output less' \
+  'fail output is correct'
+like "$output" 'not ok 6 - command output diff' \
+  'fail output is correct'
 like "$output" "#     got: 'foo'" \
   'difference reporting - got'
 like "$output" "#   expected: 'bar'" \
   'difference reporting - want'
 
-done_testing 5
+like "$output" "# Array has more elements \(3\) than expected \(2\)" \
+  'array comparison (more)'
+like "$output" "# Array has less elements \(1\) than expected \(2\)" \
+  'array comparison (less)'
+like "$output" "# array\[1\]: >>foo<< does not match >>line2<<" \
+  'array comparison (diff)'
+
+
+done_testing 11

--- a/test/more.t
+++ b/test/more.t
@@ -3,7 +3,7 @@
 source test/setup
 use Test::More
 
-plan tests 5
+plan tests 6
 
 pass 'This test always passes'
 
@@ -18,3 +18,8 @@ ok "`[[ ! team =~ I ]]`" "There's no I in team"
 # diag "A msg for stderr"
 
 note "A msg for stdout"
+
+expected=(line1 line2)
+
+command_output=(line1 line2 )
+cmp-array "command output more" ${command_output[@]}

--- a/test/test/fail1.t
+++ b/test/test/fail1.t
@@ -9,4 +9,15 @@ fail
 
 is foo bar 'is foo bar'
 
-done_testing 3
+expected=(line1 line2)
+
+command_output=(line1 line2 line3)
+cmp-array "command output more" ${command_output[@]}
+
+command_output=(line1)
+cmp-array "command output less" ${command_output[@]}
+
+command_output=(line1 foo)
+cmp-array "command output diff" ${command_output[@]}
+
+done_testing 6


### PR DESCRIPTION
My usecase is: comparing the output of several commands to a list of expected lines.
I would like to get a detailed output if I got more or less lines, and which line is different.
For perl, there's `is_deeply`, but in bash I called it `cmp-array`:
```
expected=( line1 line2 )

command_output=( $(ls) )
cmp-array "command output" ${command_output[@]}
```
Since I cannot pass two arrays to a bash function, the `expected` variable needs to be declared before.